### PR TITLE
Update edit-escrow-hints.md

### DIFF
--- a/docs/intro/edit-escrow-hints.md
+++ b/docs/intro/edit-escrow-hints.md
@@ -64,11 +64,9 @@ fn try_steal(params: Params, _state: State, destination: String) -> Result<Respo
 
 ```rust
 
-const THIEF: &str = "changeme";
-
 #[test]
 fn handle_steal() {
-    let mut store = mock_instance(WASM);
+    let mut store = MockStorage::new();
 
     // initialize the store
     let msg = init_msg(1000, 0);

--- a/docs/intro/edit-escrow-hints.md
+++ b/docs/intro/edit-escrow-hints.md
@@ -63,7 +63,6 @@ fn try_steal(params: Params, _state: State, destination: String) -> Result<Respo
 ## Test Steal
 
 ```rust
-
 #[test]
 fn handle_steal() {
     let mut store = MockStorage::new();

--- a/docs/intro/edit-escrow-hints.md
+++ b/docs/intro/edit-escrow-hints.md
@@ -63,24 +63,35 @@ fn try_steal(params: Params, _state: State, destination: String) -> Result<Respo
 ## Test Steal
 
 ```rust
+
+const THIEF: &str = "changeme";
+
 #[test]
 fn handle_steal() {
-    let mut store = MockStorage::new();
+    let mut store = mock_instance(WASM);
 
     // initialize the store
     let msg = init_msg(1000, 0);
-    let params = mock_params_height("creator", &coin("1000", "earth"), &[], 400, 0);
+    let params = mock_params_height("creator", &coin("1000", "earth"), &[], 876, 0);
     let init_res = init(&mut store, params, msg).unwrap();
     assert_eq!(0, init_res.messages.len());
 
     // not just "anybody" can steal the funds
-    let msg = to_vec(&HandleMsg::Steal { destination: "bankvault".to_string()}).unwrap();
-    let params = mock_params("anybody", &[], &coin("1000", "earth"));
+    let msg = to_vec(&HandleMsg::Steal { destination: "bankvault".to_string() }).unwrap();
+    let params = mock_params_height(
+        "anybody",
+         &[],
+         &coin("1000", "earth")
+    );
     let handle_res = handle(&mut store, params, msg.clone());
     assert!(handle_res.is_err());
 
     // only the master thief
-    let params = mock_params(THIEF, &[], &coin("1000", "earth"));
+    let params = mock_params_height(
+        THIEF,
+        &[],
+        &coin("1000", "earth")
+    );
     let handle_res = handle(&mut store, params, msg.clone()).unwrap();
     assert_eq!(1, handle_res.messages.len());
     let msg = handle_res.messages.get(0).expect("no message");


### PR DESCRIPTION
I've made a couple updates that make the tests appear more like the refund test (which you recommend copying). If the format you originally listed here is needed might be good to make reference to the changes. It might be because I tried to copy the refund test or it might be other mistakes but i'm unable to run tests successfully. It seems like I'm supposed to compile before running the tests, is this so? Actually I just ran `cargo wasm`, it compiled successfully, then ran `RUST_BACKTRACE=1 cargo unit-test` it was successful but only ran the original 5 tests.
My repo with errors can be seen here: https://github.com/okwme/cosmwasm-examples