### PR TITLE
Add documentation on using `crev`

### DIFF
--- a/docs/tooling/reviews.md
+++ b/docs/tooling/reviews.md
@@ -32,7 +32,7 @@ cargo crev crate open -u cw-erc20 0.1.0 --cmd "code --wait -n" --cmd-save
 IntelliJ:
 
 ```sh 
-cargo crev crate open -u cw-erc20 0.1.0 --cmd "code --wait -n" --cmd-save
+cargo crev crate open -u cw-erc20 0.1.0 --cmd "TODO" --cmd-save
 ```
 
 *Note:* you must be in the directory of some rust project to use `cargo crev crate`
@@ -107,9 +107,45 @@ information for everyone.
 
 ## Write your review
 
+Once you have finished reviewing the code above and lodged any issues on the official repo,
+you can write up a code review to share with the world. Close the editor and go back to the
+terminal where you ran `cargo crev crate open ...`. Now, let's go write our review:
 
-### Updating the review
+```sh
+# Clean up any edits you made while testing
+cargo crev crate clean -u cw-erc20
 
+# Write a review
+cargo crev crate review -u cw-erc20
+```
+
+In particular, make sure to correctly note your `thoroughness` and `understanding`
+as `high`, `medium`, `low` or `none`. And your `rating` as `strong`, `positive`,
+`neutral`, `negative`, or `dangerous`. There is a description of the meaning at
+the bottom of the document in your editor. Please add a decent comment explaining
+your results, and you can also add a section to link to any issues you registered on github.
+
+Please be honest. If you just did a brief check, please mark thoroughness as `low`.
+This is better than no review, but if you claim a detailed review, it can be misleading.
+Honesty counts and bad reviews can get you removed or isolated on the web of trust.
+
+Here is my submission for `cw-erc20`, please note you must indent every line in the comment block:
+
+```toml
+# Package Review of cw-erc20 0.1.0
+review:
+  thoroughness: medium
+  understanding: high
+  rating: strong
+flags:
+  unmaintained: false
+comment: |-
+  Good test coverage and simple, straight-forward code. This makes a solid base for other contracts to build on.
+  Some work may be needed to enable easier reuse in other contracts, but it is very solid to run it as-is.
+```
+
+Verify this was saved properly with `cargo crev repo query review cw-erc20` and if it looks good,
+make sure to publish it.
 
 ## Publishing
 
@@ -122,3 +158,52 @@ cargo crev repo publish
 
 Then, make sure other developers can find your review, by publishing your repo and ID
 on the [list of CosmWasm developers](./verify#cosmwasm-developers).
+
+## Visibility of contract reviews
+
+The `crev` tool is largely designed to validate dependencies. That is, crates
+that are imported by the current crate. You will notice that the current crate
+always shows up as `local`, even if there are reviews. Thus, if you check out
+a contract you wish to review and run the `crate verify` command on it,
+you will not see info on the contract itself. 
+
+You can see info on any contract you wish to reuse (not import),
+by querying the reviews directly:
+
+```sh
+cargo crev repo query review cw-erc20
+```
+
+(Interestingly, these reviews do not show up via `cargo crev crate info -u cw-erc20`).
+
+One take-away of this, is that the most essential crates to review (besides anything
+you immediately intend to put on a production blockchain), are those crates which
+are imported by others. This includes libraries, such as
+[`cw-storage`](https://github.com/confio/cw-storage), as well as contracts designed
+to be imported by others and extended (which will likely be true of a future version
+of `cw-erc20`). Doing so leverages the value of the review not just for one contract,
+but for many contracts that depend on that code.
+
+## Updating your review
+
+There are two reasons to update a review. Either you found more time and did a deeper, more thorough review
+of the same version, or a new version was published, possibly in response to issues you logged in the first version.
+In either case, you can just run the same commands as above, especially `cargo crev crate review -u cw-erc20` to submit a review.
+
+If there is a new version out there, this will submit a second review for the new version.
+This preserves important information, such as `0.2.0` fixed some important security issues that were
+present in `0.1.0`. The combination of a negative and positive review on different versions is very helpful 
+for anyone looking to reuse this code. When making the second review, you should notice that the `package.version`
+in the review file is updated.
+
+If there is no new version published to [crates.io](https://crates.io), you will see a notice in the header:
+
+```toml
+# Overwriting existing proof created on 2020-01-09T12:47:39.924625388+01:00
+# Package Review of cw-erc20 0.1.0
+```
+
+This warns you that you are about to overwrite an existing proof, rather than review a new version.
+If this is not what you expect, make sure that the crate owner has published the new version of their
+crate to [crates.io](https://crates.io). Maybe the fixes are just in `master` and you will have to
+wait for an official release to add a new review on that.

--- a/docs/tooling/reviews.md
+++ b/docs/tooling/reviews.md
@@ -1,0 +1,140 @@
+---
+id: reviews
+title: Cryptographic Code Reviews
+sidebar_label: Code Reviews
+---
+
+An essential component to creating secure, trustable smart contracts are audits
+and code reviews. We don't believe that audits should be the sole domain of a
+niche group of companies, but that many developers are also capable of reviewing each
+others code and help spot bugs and security holes. With CosmWasm, we aim to nurture
+a culture of collective code reviews to aid in our goal of open, highly secure contracts.
+
+## CRev
+
+[`crev`](https://news.ycombinator.com/item?id=18824923) is an idea of decentralized,
+cryptographically verifiable code reviews, centered around a web of trust.
+More specifically [`cargo-crev`](https://github.com/crev-dev/cargo-crev/tree/master/cargo-crev)
+is a set of tooling to enable the `crev` design with existing rust tooling,
+notably the ubiquitous `cargo` command. We support using `cargo-crev` to review all
+smart contracts and common dependencies, and will be providing a seed node of trust that
+you can sync with, and maintain a directory of some well-known CosmWasm developers. You
+can always find others by traversing the web of trust.
+
+The idea is anyone can sign and publish a review of any crate. Each developer can also
+assign trust (`low`, `medium`, `high` or `distrust`) to other developers, based on how
+much they trust the other's reviews (both honesty and quality). From this, we can pull
+in many reviews on various crates and `cargo crev crate verify` will show the current
+status of the current crate and all dependencies. Ideally all dependencies of `cosmwasm`
+and the major contracts / libraries built on it, like [cw-erc20](https://crates.io/crates/cw-erc20)
+and [cw-storage](https://crates.io/crates/cw-storage) will have multiple, public reviews,
+so we can build a solid base for security.
+
+## Getting Started
+
+I highly recommend going through the [Getting Started](https://github.com/crev-dev/cargo-crev/blob/master/cargo-crev/src/doc/getting_started.md)
+page on `cargo-crev` to understand all the elements, but we will lead you through a simple usage of it here,
+tailored to CosmWasm developers. Please note that this will assign trust to the core
+CosmWasm developer, [Ethan Frey](https://github.com/ethanfrey), but you can skip that part and
+use another seed if you already know other developers using `crev`.
+I hope the trust graph will soon be less centralized, but it is best to start with a seed
+to produce a highly connected clique. Also, please verify the trust ID in at least 2 places before
+adding it.
+
+### Installation
+
+You will first need to have `openssl` installed on your system for TLS (HTTPS) support.
+
+Ubuntu: `sudo apt-get install openssl libssl-dev`
+
+MacOS: `brew install openssl`
+
+Now, you can build the `cargo-crev` command:
+
+```sh
+cargo install cargo-crev
+cargo crev --help
+```
+
+### Creating a `CRevID`
+
+The first step to using `crev` is to create and publish your identity. We will be using
+cryptographic keys stored on your local computer to sign the trust proofs, and publishing
+the trust graph and code reviews over multiple git repositories (one for each user).
+I recommend just [following the official instructions here](https://github.com/crev-dev/cargo-crev/blob/master/cargo-crev/src/doc/getting_started.md#creating-a-crevid),
+but if you just want to cut and paste, this should get you up.
+
+[Fork the crev-proofs repo](https://github.com/crev-dev/crev-proofs/fork) to your personal github account.
+
+Or you can copy it to another git server via:
+
+```sh
+git clone https://github.com/crev-dev/crev-proofs
+cd crev-proofs
+git remote set-url origin YOUR_EMPTY_GIT_REPO_HERE
+git push -u origin master
+```
+
+Now, you can create your personal id (local to your computer, and add it to the repo:
+
+```sh
+# you need the https variant, not the git@ (ssh) variant
+cargo crev id new --url https://github.com/YOUR_NAME/crev-proofs
+```
+
+## Bootstrapping your Web of Trust
+
+You will need at least one trusted developer to get started.
+Let's pick a few reputable ones and assign them a trust level of `medium`.
+You can feel free to use different seeds if you wish, but these are the commands:
+
+Trust [`dpc`](https://github.com/dpc), one of the core `cargo-crev` developers. This will pull in many
+reviews of standard rust crates:
+
+```sh
+cargo crev repo fetch url https://github.com/dpc/crev-proofs
+cargo crev id trust FYlr8YoYGVvDwHQxqEIs89reKKDy-oWisoO0qXXEfHE
+```
+
+Trust [`ethanfrey`](https://github.com/ethanfrey), the main CosmWasm developer. This will pull
+in reviews of many `cosmwasm` related packages:
+
+```sh
+cargo crev repo fetch url https://github.com/ethanfrey/crev-proofs
+cargo crev id trust aXPP9kgM2ENNWug1ltY3AiHBDFP6NWoDcoaHM7b_i08
+```
+
+Once you have trusted one (or both) of the above seeds, you can pull in their trust graph.
+This will show up as a number of `medium` and `low` level trust rankings. We can
+then fetch all their reviews to get a large net of reviews. This cannot be used to provide
+high trust, but can definitely help spread the word on any malicious packages discovered:
+
+```sh
+cargo crev id query trusted
+cargo crev repo fetch trusted
+```
+
+It takes a while, but now you should be rewarded with some shared knowledge.
+
+## Verifying a Crate
+
+Once we have seeded the trust graph, let's try it out. Go into a local rust project
+and try to verify it. If you don't have one in particular, I suggest to
+`git clone https://github.com/confio/cosmwasm` in a new directory.
+Now that we are in the root of a rust project (in the same directory as `Cargo.toml`),
+let's check out what reviews we find in the web of trust:
+
+```sh
+cargo crev crate verify --no-dev-dependencies
+```
+
+You will see a few green `pass`, quite a few `none` (some with reviews, but from lower trusted devs),
+and maybe even a `warn`. When I first ran this, I found a `warn` message by `redox_syscall`
+and `smallvec`. Let's investigate further:
+
+```sh
+cargo crev crate info smallvec
+cargo crev crate info hex
+```
+
+TODO: how to get the reviews that caused pass/warn

--- a/docs/tooling/reviews.md
+++ b/docs/tooling/reviews.md
@@ -1,0 +1,124 @@
+---
+id: reviews
+title: Submitting a Cryptographic Code Review
+sidebar_label: Reviewing Code
+---
+
+As mentioned in [the last section](./verify), an essential component to creating secure,
+trustable smart contracts are audits and code reviews. We described how to install
+`cargo-crev`, create your own ID, bootstrap your web of trust, and verify dependencies
+on your contract. All of this makes use of the work of others. Once you have seen
+the utility of such an approach, we invite you to add your own review on some crate,
+ideally one used by your contract.
+
+There is a good description of how to [submit a review in the official docs](https://github.com/crev-dev/cargo-crev/blob/master/cargo-crev/src/doc/getting_started.md#reviewing-code),
+but here we will lead you through an example relevant to CosmWasm. In this example,
+we will do a review of the `cw-erc20` crate.
+
+## Select your editor
+
+I [recommended two free editors with good Rust support](../getting-started/rust-basics#setting-up-your-ide), VSCode and IntelliJ.
+Assuming you are using one of those, you can load up the code to review with one
+of the following commands. Not that the `--cmd` and `--cmd-save` flags are only
+needed once, after that you can omit all flags and it will remember your preference.
+You only need to include them again if you want to open with a different editor.
+
+VSCode:
+
+```sh 
+cargo crev crate open -u cw-erc20 0.1.0 --cmd "code --wait -n" --cmd-save
+```
+
+IntelliJ:
+
+```sh 
+cargo crev crate open -u cw-erc20 0.1.0 --cmd "code --wait -n" --cmd-save
+```
+
+*Note:* you must be in the directory of some rust project to use `cargo crev crate`
+(it needs a "current crate" for context). If the crate you are reviewing is not a 
+dependency of your current crate, then you must include the `-u` flag.
+
+## Go through the code
+
+If you are reviewing a smart contract, the first step is to check that the boilerplate
+looks reasonable. Check `Cargo.toml` for dependencies. If you see a `build.rs` file
+(or other script mentioned in `Cargo.toml`) do a close inspection. Ensure `lib.rs`
+looks standard (there is no real need to change it, but we need to make sure that
+eg. the `extern handle` calls `contract::handle`). Ensure the `examples/schema.rs`
+file imports types from this same contract. If you see any issues here, 
+please flag them.
+
+As a second step, you can review the submitted artifacts are correct, using the
+[standard build process](https://github.com/confio/cosmwasm-opt):
+
+```sh
+# these should be the same
+sha256sum contract.wasm
+cat hash.txt
+
+# ensure we generate the same wasm hash with a fresh build
+mv hash.txt hash_old.txt
+rm contract.wasm
+docker run --rm -v $(pwd):/code \
+  --mount type=volume,source=$(basename $(pwd))_cache,target=/code/target \
+  --mount type=volume,source=registry_cache,target=/usr/local/cargo/registry \
+  confio/cosmwasm-opt:0.6.0
+diff hash.txt hash_old.txt
+```
+
+If there is a mismatch, please file an issue on the crate you are reviewing 
+and/or [`cosmwasm-opt`](https://github.com/confio/cosmwasm-opt) if you suspect
+a non-determinism in their output. It may be a simple oversight and the `contract.wasm` 
+from an older version, so give the author a chance to fix it before flagging a
+negative review.
+
+Once you have done the basic sanity-checks, you can focus on the `src/contract.rs`
+file (or directory) and go through, with a special eye for logic errors, and test
+coverage. Run the tests yourself as well to make sure they all pass.
+(Note: if you have a permission issue with the `target` dir, just `rm -rf target` 
+and try running the tests again).
+
+```sh
+# Change the target for integration tests to use the production build
+# static WASM: &[u8] = include_bytes!("../contract.wasm");
+vi tests/integration.rs
+
+# Then run the unit and integration tests
+cargo test
+```
+
+One issue I came across in some contracts (it is subtle) is the order of load and
+save. If I do `load A, B, update A, B, save A, B`, this is usually
+correct. But what if `A` and `B` are the same? In the case of a token transfer,
+this may mean sending to myself will decrease and increment the same account, but
+only the last save will count (just the increment). To be more secure, make sure
+you save one object before loading the next one if there is any chance of them being
+the same: `load, update, save A. load, update, save B`. Note that the 
+[`cw-storage`](https://github.com/confio/cw-storage) crate provides a helper
+for just this case to help avoid such bugs:
+[`TypedStorage.update`](https://github.com/confio/cw-storage/blob/master/src/typed.rs#L72-L81).
+
+Please make sure to file issues on the crates github account for any issue you discover,
+and link them to the review. If the crate owner responds with a new version fixing the filed bugs, 
+please review the changes, and submit a new review for the next published version. This may, for example,
+signal to other users than `0.1.0` has some security warnings, but `0.1.1` is safe to use - valuable
+information for everyone.
+
+## Write your review
+
+
+### Updating the review
+
+
+## Publishing
+
+Once you have created a review, you will want to share it with the world.
+First, you need to publish it to your personal `crev-proofs` repo:
+
+```sh
+cargo crev repo publish
+```
+
+Then, make sure other developers can find your review, by publishing your repo and ID
+on the [list of CosmWasm developers](./verify#cosmwasm-developers).

--- a/docs/tooling/reviews.md
+++ b/docs/tooling/reviews.md
@@ -125,28 +125,66 @@ Now that we are in the root of a rust project (in the same directory as `Cargo.t
 let's check out what reviews we find in the web of trust:
 
 ```sh
+cargo crev crate clean
 cargo crev crate verify --no-dev-dependencies
 ```
 
 You will see a few green `pass`, quite a few `none` (some with reviews, but from lower trusted devs),
 and maybe even a `warn`. When I first ran this, I found a `warn` message by `redox_syscall`
-and `smallvec`. Let's investigate further:
+and `smallvec`. Let's investigate further. You can get some general info on the crates:
 
 ```sh
 cargo crev crate info smallvec
 cargo crev crate info hex
 ```
 
-TODO: how to get the reviews that caused pass/warn
+But if you want to get the full reviews, you must use:
+
+```sh
+cargo crev repo query review hex
+cargo crev repo query review smallvec
+
+# to find negative reviews, you can also query related advisories and issues
+cargo crev repo query advisory smallvec
+cargo crev repo query issue smallvec
+```
+
+### Test your contract
+
+Go to the directory of a smart contract you created, or go to the `escrow`
+contract in [`https://github.com/confio/cosmwasm-examples`](https://github.com/confio/cosmwasm-examples)
+if you don't have your own contract. These have fewer dependencies, and I would really
+like to get all of the common dependencies reviewed in the mid-term. Due to the
+feature flags in contracts derived from [`cosmwasm-template`](https://github.com/confio/cosmwasm-template),
+you will need the following (notice extra flag on verify):
+
+```sh
+cargo crev crate clean
+cargo crev crate verify --no-dev-dependencies --no-default-features
+```
+
+My check shows a number of `pass` and no `warn`, a good start. Also, a number
+of the `none` crates, have a positive review on a slightly older version
+of the same crate, so those should be low hanging fruit to update.
 
 ## Publishing your Web of Trust
 
-TODO
+Now that you have learned some tools, feel free to add a few other developers
+to your web of trust, and then publish your key here, so we can start connecting.
 
 ```sh
 cargo crev repo publish
 ```
 
-## Reviewing a Crate
+### CosmWasm Developers
 
-TODO
+Beyond the [seeds listed above](#bootstrapping-your-web-of-trust), we can list some
+known developers working on CosmWasm. These may add relevant reviews, but only add
+them if you know them (or their work) beyond this website.
+
+**None**
+
+Please [create a PR on `cosmwasm/docs`](https://github.com/cosmwasm/docs/pulls) if you want to be
+on this list. Anyone that has contributed to cosmwasm or published a cosmwasm-based
+contract is eligable to be on the list. It is not curated, so please make your own
+decision if you know and trust these developers.

--- a/docs/tooling/reviews.md
+++ b/docs/tooling/reviews.md
@@ -29,10 +29,10 @@ VSCode:
 cargo crev crate open -u cw-erc20 0.1.0 --cmd "code --wait -n" --cmd-save
 ```
 
-IntelliJ:
+IntelliJ: (only works when no IntelliJ window is currently open)
 
 ```sh 
-cargo crev crate open -u cw-erc20 0.1.0 --cmd "TODO" --cmd-save
+cargo crev crate open -u cw-erc20 0.1.0 --cmd "idea.sh" --cmd-save
 ```
 
 *Note:* you must be in the directory of some rust project to use `cargo crev crate`

--- a/docs/tooling/reviews.md
+++ b/docs/tooling/reviews.md
@@ -150,7 +150,14 @@ make sure to publish it.
 ## Publishing
 
 Once you have created a review, you will want to share it with the world.
-First, you need to publish it to your personal `crev-proofs` repo:
+You can see which updates you have not yet published, but reviewing your local
+git history:
+
+```sh
+cargo crev repo git log
+```
+
+Once you are sure these updates are ready to share, you need to publish it to your personal `crev-proofs` repo:
 
 ```sh
 cargo crev repo publish

--- a/docs/tooling/reviews.md
+++ b/docs/tooling/reviews.md
@@ -138,3 +138,15 @@ cargo crev crate info hex
 ```
 
 TODO: how to get the reviews that caused pass/warn
+
+## Publishing your Web of Trust
+
+TODO
+
+```sh
+cargo crev repo publish
+```
+
+## Reviewing a Crate
+
+TODO

--- a/docs/tooling/verify.md
+++ b/docs/tooling/verify.md
@@ -101,7 +101,9 @@ in reviews of many `cosmwasm` related packages:
 
 ```sh
 cargo crev repo fetch url https://github.com/ethanfrey/crev-proofs
+# two ids for different devices
 cargo crev id trust aXPP9kgM2ENNWug1ltY3AiHBDFP6NWoDcoaHM7b_i08
+cargo crev id trust Fa_KJe6fi4eDoak8SGkysvRCNjZP4IC03L05iw_vepI
 ```
 
 Once you have trusted one (or both) of the above seeds, you can pull in their trust graph.

--- a/docs/tooling/verify.md
+++ b/docs/tooling/verify.md
@@ -1,7 +1,7 @@
 ---
-id: reviews
-title: Cryptographic Code Reviews
-sidebar_label: Code Reviews
+id: verify
+title: Verifying with Cryptographic Code Reviews
+sidebar_label: Verifying Code
 ---
 
 An essential component to creating secure, trustable smart contracts are audits

--- a/docs/tooling/verify.md
+++ b/docs/tooling/verify.md
@@ -188,3 +188,10 @@ Please [create a PR on `cosmwasm/docs`](https://github.com/cosmwasm/docs/pulls) 
 on this list. Anyone that has contributed to cosmwasm or published a cosmwasm-based
 contract is eligable to be on the list. It is not curated, so please make your own
 decision if you know and trust these developers.
+
+### Rust Developers
+
+You can also check out the [crev proof repository list](https://github.com/crev-dev/cargo-crev/wiki/List-of-Proof-Repositories)
+to get a list of general Rust developers who have been submitting proofs for other
+crates. If you have reviewed some general (non cosmwasm-specific) crates, you may
+also want to add yourself to that list.

--- a/website/sidebars.json
+++ b/website/sidebars.json
@@ -19,6 +19,10 @@
     ],
     "Name Service": [
       "name-service/intro"
+    ],
+    "Production Tooling": [
+      "tooling/verify",
+      "tooling/reviews"
     ]
   }
 }


### PR DESCRIPTION
Added new section "Production Tooling" and a detailed guide to set up `cargo-crev` locally,
and use it to verify and review CosmWasm contracts.

Closes https://github.com/confio/crev-proofs/issues/3